### PR TITLE
Fix Windows 10 Creator issue

### DIFF
--- a/src/Overlay.NET.Demo/Directx/DirectxOverlayPluginExample.cs
+++ b/src/Overlay.NET.Demo/Directx/DirectxOverlayPluginExample.cs
@@ -68,6 +68,7 @@ namespace Overlay.NET.Demo.Directx {
                 return;
             }
 
+            OverlayWindow.Update();
             InternalRender();
         }
 

--- a/src/Overlay.NET.Demo/Overlay.NET.Demo.csproj
+++ b/src/Overlay.NET.Demo/Overlay.NET.Demo.csproj
@@ -36,25 +36,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Overlay.NET, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Overlay.NET.1.0.2\lib\Overlay.NET.dll</HintPath>
-    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="Process.NET, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Overlay.NET.1.0.2\lib\Process.NET.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX, Version=3.1.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\Overlay.NET.1.0.2\lib\SharpDX.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.Direct2D1, Version=3.1.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\Overlay.NET.1.0.2\lib\SharpDX.Direct2D1.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.DXGI, Version=3.1.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\Overlay.NET.1.0.2\lib\SharpDX.DXGI.dll</HintPath>
-    </Reference>
-    <Reference Include="SharpDX.Mathematics, Version=3.1.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\Overlay.NET.1.0.2\lib\SharpDX.Mathematics.dll</HintPath>
+      <HintPath>..\packages\Process.NET.1.0.8\lib\Process.NET.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -75,6 +60,12 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Overlay.NET\Overlay.NET.csproj">
+      <Project>{2d411ea5-bc00-4630-b25e-43c554323e72}</Project>
+      <Name>Overlay.NET</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Overlay.NET.Demo/packages.config
+++ b/src/Overlay.NET.Demo/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
-  <package id="Overlay.NET" version="1.0.2" targetFramework="net462" />
+  <package id="Process.NET" version="1.0.8" targetFramework="net462" />
 </packages>

--- a/src/Overlay.NET/App.config
+++ b/src/Overlay.NET/App.config
@@ -4,4 +4,13 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
   </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="SharpDX" publicKeyToken="b4dcf0f35e5521f1" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+
 </configuration>

--- a/src/Overlay.NET/Common/WindowConstants.cs
+++ b/src/Overlay.NET/Common/WindowConstants.cs
@@ -15,7 +15,7 @@ namespace Overlay.NET.Common {
         /// <summary>
         ///     The desktop class
         /// </summary>
-        public const string DesktopClass = "#32769";
+        public const string DesktopClass = "Static"; // System Class for a static control
 
         /// <summary>
         ///     The window style dx
@@ -32,6 +32,11 @@ namespace Overlay.NET.Common {
                                             | 0x80 //WS_EX_TOOLWINDOW -> Not in taskbar
                                             | 0x8 //WS_EX_TOPMOST
                                             | 0x20; //WS_EX_TRANSPARENT
+
+        /// <summary>
+        ///     The layered window attribute alpha (LWA_ALPHA)
+        /// </summary>
+        public const int LwaAlpha = 0x00000002;
 
         /// <summary>
         ///     The HWND notopmost

--- a/src/Overlay.NET/Directx/DirectXOverlayWindow.cs
+++ b/src/Overlay.NET/Directx/DirectXOverlayWindow.cs
@@ -162,8 +162,6 @@ namespace Overlay.NET.Directx {
             Graphics = new Direct2DRenderer(Handle, limitFps);
 
             SetBounds(X, Y, Width, Height);
-
-            Task.Run(() => ParentServiceThread());
         }
 
         /// <summary>
@@ -207,25 +205,26 @@ namespace Overlay.NET.Directx {
                 return false;
             }
 
+            Native.SetLayeredWindowAttributes(Handle, 0, 255, WindowConstants.LwaAlpha);
+
             ExtendFrameIntoClient();
 
             return true;
         }
 
         /// <summary>
-        ///     resize and set new position if the parent window's bounds change
+        /// Resize and set new position if the parent window's bounds change
         /// </summary>
-        private void ParentServiceThread() {
-            while (!IsDisposing) {
-                Thread.Sleep(10);
+        public void Update() {
+            if (!ParentWindowExists)
+                return;
 
-                Native.Rect bounds;
-                Native.GetWindowRect(ParentWindow, out bounds);
+            Native.Rect bounds;
+            Native.GetWindowRect(ParentWindow, out bounds);
 
-                if (X != bounds.Left || Y != bounds.Top || Width != bounds.Right - bounds.Left ||
-                    Height != bounds.Bottom - bounds.Top) {
-                    SetBounds(bounds.Left, bounds.Top, bounds.Right - bounds.Left, bounds.Bottom - bounds.Top);
-                }
+            if (X != bounds.Left || Y != bounds.Top || Width != bounds.Right - bounds.Left ||
+                Height != bounds.Bottom - bounds.Top) {
+                SetBounds(bounds.Left, bounds.Top, bounds.Right - bounds.Left, bounds.Bottom - bounds.Top);
             }
         }
 
@@ -249,16 +248,7 @@ namespace Overlay.NET.Directx {
             X = x;
             Y = y;
 
-            Native.Point pos;
-            pos.X = x;
-            pos.Y = y;
-
-            Native.Point size;
-            size.X = Width;
-            size.Y = Height;
-
-            Native.UpdateLayeredWindow(Handle, IntPtr.Zero, ref pos, ref size, IntPtr.Zero, IntPtr.Zero, 0, IntPtr.Zero,
-                0);
+            Native.SetWindowPos(Handle, WindowConstants.HwndTopmost, X, Y, Width, Height, 0);
 
             ExtendFrameIntoClient();
         }
@@ -272,16 +262,7 @@ namespace Overlay.NET.Directx {
             Width = width;
             Height = height;
 
-            Native.Point pos;
-            pos.X = X;
-            pos.Y = Y;
-
-            Native.Point size;
-            size.X = Width;
-            size.Y = Height;
-
-            Native.UpdateLayeredWindow(Handle, IntPtr.Zero, ref pos, ref size, IntPtr.Zero, IntPtr.Zero, 0, IntPtr.Zero,
-                0);
+            Native.SetWindowPos(Handle, WindowConstants.HwndTopmost, X, Y, Width, Height, 0);
 
             Graphics.AutoResize(Width, Height);
 
@@ -301,16 +282,7 @@ namespace Overlay.NET.Directx {
             Width = width;
             Height = height;
 
-            Native.Point pos;
-            pos.X = x;
-            pos.Y = y;
-
-            Native.Point size;
-            size.X = Width;
-            size.Y = Height;
-
-            Native.UpdateLayeredWindow(Handle, IntPtr.Zero, ref pos, ref size, IntPtr.Zero, IntPtr.Zero, 0, IntPtr.Zero,
-                0);
+            Native.SetWindowPos(Handle, WindowConstants.HwndTopmost, X, Y, Width, Height, 0);
 
             Graphics?.AutoResize(Width, Height);
 

--- a/src/Overlay.NET/Overlay.NET.csproj
+++ b/src/Overlay.NET/Overlay.NET.csproj
@@ -42,17 +42,17 @@
     <Reference Include="Process.NET, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Process.NET.1.0.8\lib\Process.NET.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX, Version=3.1.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.3.1.2-beta109\lib\net45\SharpDX.dll</HintPath>
+    <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.Direct2D1, Version=3.1.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.Direct2D1.3.1.2-beta109\lib\net45\SharpDX.Direct2D1.dll</HintPath>
+    <Reference Include="SharpDX.Direct2D1, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.Direct2D1.4.2.0\lib\net45\SharpDX.Direct2D1.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.DXGI, Version=3.1.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.DXGI.3.1.2-beta109\lib\net45\SharpDX.DXGI.dll</HintPath>
+    <Reference Include="SharpDX.DXGI, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.DXGI.4.2.0\lib\net45\SharpDX.DXGI.dll</HintPath>
     </Reference>
-    <Reference Include="SharpDX.Mathematics, Version=3.1.2.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpDX.Mathematics.3.1.2-beta109\lib\net45\SharpDX.Mathematics.dll</HintPath>
+    <Reference Include="SharpDX.Mathematics, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpDX.Mathematics.4.2.0\lib\net45\SharpDX.Mathematics.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/src/Overlay.NET/packages.config
+++ b/src/Overlay.NET/packages.config
@@ -1,9 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <packages>
   <package id="Process.NET" version="1.0.8" targetFramework="net461" />
-  <package id="SharpDX" version="3.1.2-beta109" targetFramework="net461" />
-  <package id="SharpDX.Direct2D1" version="3.1.2-beta109" targetFramework="net461" />
-  <package id="SharpDX.DXGI" version="3.1.2-beta109" targetFramework="net461" />
-  <package id="SharpDX.Mathematics" version="3.1.2-beta109" targetFramework="net461" />
+  <package id="SharpDX" version="4.2.0" targetFramework="net462" />
+  <package id="SharpDX.Direct2D1" version="4.2.0" targetFramework="net462" />
+  <package id="SharpDX.DXGI" version="4.2.0" targetFramework="net462" />
+  <package id="SharpDX.Mathematics" version="4.2.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
I have a working solution.
I have :
- Replace invalid classname "#32769" by "Static".
- Switch to SetLayeredWindowAttribute behavior :
- - SetWindowPos used instead of UpdateLayeredWindow
- - Replace ParentServiceThread by new Update method because SetWindowPos need an event loop to resize/pos from an other thread than gui.